### PR TITLE
Open Feed URLs in OCReader

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,33 @@
 
                 <data android:mimeType="text/plain" />
             </intent-filter>
+            <intent-filter android:label="@string/add_new_feed">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:scheme="http" />
+                <data android:host="*"/>
+                <data android:mimeType="application/atom+xml"/>
+                <data android:mimeType="application/rss+xml"/>
+                <data android:mimeType="application/xml"/>
+                <data android:mimeType="text/xml"/>
+            </intent-filter>
+            <intent-filter android:label="@string/add_new_feed">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:scheme="http" />
+                <data android:host="*"/>
+                <data android:pathPattern=".*\\.xml"/>
+                <data android:pathPattern=".*\\.rss"/>
+                <data android:pathPattern=".*\\.atom"/>
+            </intent-filter>
         </activity>
         <activity
             android:name=".SettingsActivity"

--- a/app/src/main/java/email/schaal/ocreader/ManageFeedsActivity.kt
+++ b/app/src/main/java/email/schaal/ocreader/ManageFeedsActivity.kt
@@ -44,9 +44,9 @@ class ManageFeedsActivity : AppCompatActivity(), FeedManageListener {
         binding.feedsRecyclerview.layoutManager = LinearLayoutManager(this)
         binding.feedsRecyclerview.addItemDecoration(DividerItemDecoration(this, R.dimen.divider_inset))
         binding.fabAddFeed.setOnClickListener { AddNewFeedDialogFragment.show(this@ManageFeedsActivity, null, false) }
-        if (Intent.ACTION_SEND == intent.action) {
+        if (Intent.ACTION_SEND == intent.action || Intent.ACTION_VIEW == intent.action) {
             val feed = Feed(-1)
-            feed.url = intent.getStringExtra(Intent.EXTRA_TEXT) ?: ""
+            feed.url = intent.getStringExtra(Intent.EXTRA_TEXT) ?: intent.dataString ?: ""
             AddNewFeedDialogFragment.show(this, feed, true)
         }
     }


### PR DESCRIPTION
This PR adds new intent-filters that allow the user to open URLs matching the following criteria in OCReader and add them as new feeds:
- URL scheme: `https` or `http`
- URL host: any (`*`)
- One of the following MIME types: `application/atom+xml`, `application/rss+xml`, `application/xml`, `text/xml`
- OR one of the follwing path endings: `*.xml`, `*.rss`, `*.atom`

Looks like this in action:

![Android's "Open with" dialog showing OCReader as one of the options for opening a feed URL](https://user-images.githubusercontent.com/5564491/106266670-0448e780-6229-11eb-8788-a7277fed2662.png)
![OCReader's "Add new feed" dialog with the feed URL pre-inserted](https://user-images.githubusercontent.com/5564491/106266744-1a56a800-6229-11eb-9d8a-11e6e699da86.png)

